### PR TITLE
Add economic model app and tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[server]
+headless = true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
-# Grafico-IF
+# Keynesian Cross Interactive Model
+
+This project provides a small economic simulator written in Python. It focuses on the basic Keynesian cross model widely used in introductory macroeconomics. The model illustrates how aggregate demand (AD) depends on income and how equilibrium output is determined when planned expenditure equals actual production. The repository includes a Streamlit application to explore the model interactively, a set of reusable Python modules, and unit tests that validate the economic relationships. A GitHub Actions workflow ensures that changes continue to pass the test suite.
+
+## Economic background
+
+The Keynesian cross is a simple framework capturing the short‑run relationship between output and planned spending. Households decide how much to consume based on disposable income, while firms plan investment according to the interest rate. Government spending and taxation are treated as policy variables. Formally, consumption is
+
+```
+C = α + β(Y − T)
+```
+
+where `α` is autonomous consumption, `β` is the marginal propensity to consume (MPC), `Y` is income, and `T` represents taxes. Investment decreases with the interest rate `r` according to
+
+```
+I = I0 − I1 r
+```
+
+Government spending `G` is assumed exogenous. Planned expenditure is then
+
+```
+AD = C + I + G
+```
+
+Equilibrium occurs when planned expenditure equals output (`Y = AD`). Solving this equation yields the level of income that clears the goods market. The solution is
+
+```
+Y = [α + I0 − I1 r + G − β T] / (1 − β)
+```
+
+The repository implements these formulas in straightforward Python functions. Although highly stylized, the model conveys the intuition of how fiscal policy and interest‑rate movements shift aggregate demand and, in turn, output.
+
+## Repository structure
+
+```
+app.py                  – Streamlit user interface
+requirements.txt        – Python dependencies
+src/
+    parameters.py       – Data classes for model parameters
+    model.py            – Consumption, investment and AD functions
+    solver.py           – Closed form solution for equilibrium
+    charts.py           – Plotly chart helpers
+tests/
+    test_model.py       – Unit test for aggregate demand
+    test_solver.py      – Unit test for the solver
+.streamlit/config.toml  – Streamlit configuration
+.github/workflows/      – Continuous integration via GitHub Actions
+```
+
+All economic logic resides within the `src` package, making it easy to import the functions into other projects or extend the model. The Streamlit application in `app.py` acts as a thin layer on top of these modules. Users can tweak parameters with sliders and immediately see how equilibrium output changes. A Plotly chart displays the aggregate demand curve together with the 45‑degree line commonly used in textbook diagrams. A dashed vertical marker highlights the equilibrium level of output.
+
+## Usage
+
+1. **Install dependencies.** Create a Python 3.11 virtual environment and install the packages:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. **Run the app.** Launch Streamlit from the command line:
+   ```bash
+   streamlit run app.py
+   ```
+   A browser window will open showing sliders for the parameters. Adjusting these sliders updates the graph and equilibrium calculation in real time.
+
+3. **Execute tests.** To make sure all functions behave as expected, run:
+   ```bash
+   pytest -q
+   ```
+   The included tests verify that aggregate demand is calculated correctly and that the closed form solver matches the economic formula derived above. Continuous integration on GitHub also runs these tests automatically for each push and pull request.
+
+The project purposely avoids external data sources or advanced numerical solvers in order to remain lightweight. Nonetheless, it provides a foundation for exploring economic dynamics, experimenting with fiscal policy, or teaching the mechanics of the Keynesian cross. Because the model is coded in simple Python modules, you can easily modify or extend it—perhaps by adding an external sector, introducing expectations, or connecting it with econometric data.
+
+## Contributing
+
+Contributions are welcome. Please open an issue or pull request if you spot a bug or would like to discuss an enhancement. All changes should include appropriate tests so that the continuous integration workflow remains green.
+
+## License
+
+This project is released under the MIT License, allowing broad reuse as long as the license terms are preserved.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+import streamlit as st
+from src.parameters import Parameters
+from src.model import aggregate_demand
+from src.solver import solve_equilibrium
+from src import charts
+
+st.set_page_config(page_title="Keynesian Cross", layout="centered")
+
+st.title("Keynesian Cross Model")
+
+with st.sidebar:
+    st.header("Parameters")
+    alpha = st.number_input("Autonomous Consumption (alpha)", value=50.0)
+    beta = st.slider("MPC (beta)", min_value=0.0, max_value=0.9, value=0.6)
+    invest_intercept = st.number_input("Investment Intercept", value=40.0)
+    invest_slope = st.number_input("Investment Slope", value=5.0)
+    government = st.number_input("Government Spending", value=20.0)
+    tax = st.number_input("Taxes", value=10.0)
+    interest = st.number_input("Interest Rate", value=2.0)
+    params = Parameters(alpha=alpha, beta=beta,
+                        investment_intercept=invest_intercept,
+                        investment_slope=invest_slope,
+                        government=government,
+                        tax=tax)
+
+equilibrium = solve_equilibrium(params, interest)
+
+st.write(f"### Equilibrium Output: {equilibrium:.2f}")
+
+y_range = charts.default_range(equilibrium)
+fig = charts.ad_chart(params, interest, y_range)
+
+st.plotly_chart(fig, use_container_width=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+streamlit>=1.30.0
+plotly>=5.18.0
+numpy>=1.23
+pytest>=7.0

--- a/src/charts.py
+++ b/src/charts.py
@@ -1,0 +1,31 @@
+"""Utilities for plotting using Plotly."""
+import numpy as np
+import plotly.graph_objects as go
+
+from .parameters import Parameters
+from .model import aggregate_demand
+from .solver import solve_equilibrium
+
+
+def default_range(equilibrium: float, span: float = 100) -> np.ndarray:
+    """Return a symmetric range around equilibrium for plotting."""
+    lower = max(0, equilibrium - span)
+    upper = equilibrium + span
+    return np.linspace(lower, upper, 100)
+
+
+def ad_curve(params: Parameters, interest_rate: float, y_values: np.ndarray) -> np.ndarray:
+    """Compute aggregate demand curve for many income levels."""
+    return np.array([aggregate_demand(params, interest_rate, y) for y in y_values])
+
+
+def ad_chart(params: Parameters, interest_rate: float, y_values: np.ndarray) -> go.Figure:
+    """Build a Plotly figure showing AD and the 45-degree line."""
+    ad = ad_curve(params, interest_rate, y_values)
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=y_values, y=ad, name="AD"))
+    fig.add_trace(go.Scatter(x=y_values, y=y_values, name="45-degree"))
+    eq_y = solve_equilibrium(params, interest_rate)
+    fig.add_vline(eq_y, line_dash="dash", line_color="green")
+    fig.update_layout(xaxis_title="Income (Y)", yaxis_title="Planned Expenditure")
+    return fig

--- a/src/model.py
+++ b/src/model.py
@@ -1,0 +1,17 @@
+"""Core economic relations for the Keynesian cross."""
+from .parameters import Parameters
+
+
+def consumption(params: Parameters, income: float) -> float:
+    """Compute consumption given income."""
+    return params.alpha + params.beta * (income - params.tax)
+
+
+def investment(params: Parameters, interest_rate: float) -> float:
+    """Investment as decreasing function of the interest rate."""
+    return params.investment_intercept - params.investment_slope * interest_rate
+
+
+def aggregate_demand(params: Parameters, interest_rate: float, income: float) -> float:
+    """Return aggregate demand at given income and interest rate."""
+    return consumption(params, income) + investment(params, interest_rate) + params.government

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -1,0 +1,13 @@
+"""Parameter configuration for the Keynesian model."""
+from dataclasses import dataclass
+
+@dataclass
+class Parameters:
+    """Holds all exogenous parameters for the model."""
+
+    alpha: float
+    beta: float
+    investment_intercept: float
+    investment_slope: float
+    government: float
+    tax: float

--- a/src/solver.py
+++ b/src/solver.py
@@ -1,0 +1,16 @@
+"""Closed form solver for the Keynesian cross."""
+from .parameters import Parameters
+from .model import aggregate_demand
+
+
+def solve_equilibrium(params: Parameters, interest_rate: float) -> float:
+    """Solve for income where planned expenditure equals output."""
+    numerator = (
+        params.alpha
+        + params.investment_intercept
+        - params.investment_slope * interest_rate
+        + params.government
+        - params.beta * params.tax
+    )
+    denominator = 1 - params.beta
+    return numerator / denominator

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,15 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import numpy as np
+from src.parameters import Parameters
+from src.model import aggregate_demand
+
+
+def test_aggregate_demand():
+    params = Parameters(alpha=50, beta=0.6, investment_intercept=40,
+                        investment_slope=5, government=20, tax=10)
+    y = 100
+    r = 2
+    ad = aggregate_demand(params, r, y)
+    expected = 50 + 0.6 * (100 - 10) + 40 - 5 * 2 + 20
+    assert np.isclose(ad, expected)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,0 +1,14 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from src.parameters import Parameters
+from src.solver import solve_equilibrium
+
+
+def test_solve_equilibrium():
+    params = Parameters(alpha=50, beta=0.6, investment_intercept=40,
+                        investment_slope=5, government=20, tax=10)
+    r = 2
+    y = solve_equilibrium(params, r)
+    # analytic solution
+    expected = (50 + 40 - 5 * r + 20 - 0.6 * 10) / (1 - 0.6)
+    assert abs(y - expected) < 1e-8


### PR DESCRIPTION
## Summary
- add Streamlit Keynesian model app
- implement model, solver, and plotting
- include tests and GitHub Actions workflow
- update README with usage instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f99c1c9448322b99324fda6f4c73a