### PR TITLE
Add default_range helper

### DIFF
--- a/src/charts.py
+++ b/src/charts.py
@@ -4,6 +4,13 @@ from plotly.subplots import make_subplots
 import numpy as np
 
 
+def default_range(equilibrium: float, span: float = 100) -> np.ndarray:
+    """Return a symmetric Y range around the equilibrium level."""
+    lower = max(0, equilibrium - span)
+    upper = equilibrium + span
+    return np.linspace(lower, upper, 100)
+
+
 def build_canvas(data: dict) -> go.Figure:
     """Build the complete DD-AA model visualization with all subplots."""
     


### PR DESCRIPTION
## Summary
- add missing helper `default_range` for backward compatibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `streamlit run app.py` *(no errors)*

------
https://chatgpt.com/codex/tasks/task_e_683fa47ca0bc83228a6a43a9ef3b3119