### PR TITLE
Add React skeleton for NutriPlane

### DIFF
--- a/nutriplane/index.html
+++ b/nutriplane/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NutriPlane</title>
+  </head>
+  <body class="min-h-screen bg-gray-50">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/nutriplane/package.json
+++ b/nutriplane/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "nutriplane",
+  "version": "0.2.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0",
+    "tailwindcss": "^3.4.4",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.34",
+    "@vitejs/plugin-react": "^4.2.0"
+  }
+}

--- a/nutriplane/postcss.config.js
+++ b/nutriplane/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  }
+}

--- a/nutriplane/src/App.jsx
+++ b/nutriplane/src/App.jsx
@@ -1,0 +1,25 @@
+import { Routes, Route, Navigate } from 'react-router-dom'
+import Home from './routes/Home'
+import Planejamento from './routes/Planejamento'
+import ListaCompras from './routes/ListaCompras'
+import ResumoMacros from './routes/ResumoMacros'
+import ImportadorPlanilha from './routes/ImportadorPlanilha'
+import Header from './components/Header'
+
+export default function App() {
+  return (
+    <div className="min-h-screen">
+      <Header />
+      <main className="p-4">
+        <Routes>
+          <Route path="/" element={<Navigate to="/planejamento" />} />
+          <Route path="/home" element={<Home />} />
+          <Route path="/planejamento" element={<Planejamento />} />
+          <Route path="/compras" element={<ListaCompras />} />
+          <Route path="/resumo" element={<ResumoMacros />} />
+          <Route path="/importar" element={<ImportadorPlanilha />} />
+        </Routes>
+      </main>
+    </div>
+  )
+}

--- a/nutriplane/src/components/CardAlimento.jsx
+++ b/nutriplane/src/components/CardAlimento.jsx
@@ -1,0 +1,8 @@
+export default function CardAlimento({ nome, quantidade }) {
+  return (
+    <div className="flex justify-between border-b py-1">
+      <span>{nome}</span>
+      <span className="text-sm text-gray-500">{quantidade}</span>
+    </div>
+  )
+}

--- a/nutriplane/src/components/CardRefeicao.jsx
+++ b/nutriplane/src/components/CardRefeicao.jsx
@@ -1,0 +1,8 @@
+export default function CardRefeicao({ nome }) {
+  return (
+    <div className="border rounded p-4 shadow-sm bg-white">
+      <header className="font-semibold mb-2">{nome}</header>
+      <p className="text-gray-600 text-sm">Adicione alimentos aqui.</p>
+    </div>
+  )
+}

--- a/nutriplane/src/components/DiaSelector.jsx
+++ b/nutriplane/src/components/DiaSelector.jsx
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+
+const dias = ['Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb', 'Dom']
+
+export default function DiaSelector() {
+  const [dia, setDia] = useState(0)
+
+  return (
+    <div className="flex gap-2">
+      {dias.map((d, i) => (
+        <button
+          key={d}
+          onClick={() => setDia(i)}
+          className={`px-2 py-1 rounded ${dia === i ? 'bg-blue-500 text-white' : 'bg-gray-200'}`}
+        >
+          {d}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/nutriplane/src/components/GraficoMacros.jsx
+++ b/nutriplane/src/components/GraficoMacros.jsx
@@ -1,0 +1,7 @@
+export default function GraficoMacros() {
+  return (
+    <div className="h-40 bg-gray-200 flex items-center justify-center">
+      Gráfico de macros
+    </div>
+  )
+}

--- a/nutriplane/src/components/Header.jsx
+++ b/nutriplane/src/components/Header.jsx
@@ -1,0 +1,17 @@
+import { NavLink } from 'react-router-dom'
+
+const linkClass = ({ isActive }) =>
+  `px-3 py-2 ${isActive ? 'font-bold text-blue-600' : 'text-gray-600'}`
+
+export default function Header() {
+  return (
+    <header className="bg-white border-b shadow-sm">
+      <nav className="container mx-auto flex gap-4 p-4 text-sm">
+        <NavLink to="/planejamento" className={linkClass}>Planejamento</NavLink>
+        <NavLink to="/compras" className={linkClass}>Compras</NavLink>
+        <NavLink to="/resumo" className={linkClass}>Resumo</NavLink>
+        <NavLink to="/importar" className={linkClass}>Importar</NavLink>
+      </nav>
+    </header>
+  )
+}

--- a/nutriplane/src/components/ModalAdicionarAlimento.jsx
+++ b/nutriplane/src/components/ModalAdicionarAlimento.jsx
@@ -1,0 +1,5 @@
+export default function ModalAdicionarAlimento() {
+  return (
+    <div className="p-4">Modal de adicionar alimento</div>
+  )
+}

--- a/nutriplane/src/components/TabelaResumo.jsx
+++ b/nutriplane/src/components/TabelaResumo.jsx
@@ -1,0 +1,18 @@
+export default function TabelaResumo() {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr>
+          <th className="text-left">Macro</th>
+          <th className="text-right">Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Proteína</td>
+          <td className="text-right">0g</td>
+        </tr>
+      </tbody>
+    </table>
+  )
+}

--- a/nutriplane/src/data/alimentos.json
+++ b/nutriplane/src/data/alimentos.json
@@ -1,0 +1,11 @@
+[
+  {
+    "nome": "Ovo cozido",
+    "categoria": "Proteína",
+    "calorias": 70,
+    "proteina": 6,
+    "carboidrato": 0,
+    "gordura": 5,
+    "unidade_padrao": "1 unid"
+  }
+]

--- a/nutriplane/src/index.css
+++ b/nutriplane/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/nutriplane/src/main.jsx
+++ b/nutriplane/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/nutriplane/src/routes/Home.jsx
+++ b/nutriplane/src/routes/Home.jsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-2">Selecione a semana</h2>
+      <p className="text-gray-600">Funcionalidade em desenvolvimento.</p>
+    </div>
+  )
+}

--- a/nutriplane/src/routes/ImportadorPlanilha.jsx
+++ b/nutriplane/src/routes/ImportadorPlanilha.jsx
@@ -1,0 +1,8 @@
+export default function ImportadorPlanilha() {
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-2">Importar Planilha</h2>
+      <p className="text-gray-600">Arraste e solte sua planilha (.xlsx) aqui.</p>
+    </div>
+  )
+}

--- a/nutriplane/src/routes/ListaCompras.jsx
+++ b/nutriplane/src/routes/ListaCompras.jsx
@@ -1,0 +1,8 @@
+export default function ListaCompras() {
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-2">Lista de Compras</h2>
+      <p className="text-gray-600">Gerada a partir do planejamento semanal.</p>
+    </div>
+  )
+}

--- a/nutriplane/src/routes/Planejamento.jsx
+++ b/nutriplane/src/routes/Planejamento.jsx
@@ -1,0 +1,15 @@
+import DiaSelector from '../components/DiaSelector'
+import CardRefeicao from '../components/CardRefeicao'
+
+export default function Planejamento() {
+  return (
+    <div>
+      <DiaSelector />
+      <div className="mt-4 space-y-4">
+        <CardRefeicao nome="Café da manhã" />
+        <CardRefeicao nome="Almoço" />
+        <CardRefeicao nome="Jantar" />
+      </div>
+    </div>
+  )
+}

--- a/nutriplane/src/routes/ResumoMacros.jsx
+++ b/nutriplane/src/routes/ResumoMacros.jsx
@@ -1,0 +1,8 @@
+export default function ResumoMacros() {
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-2">Resumo de Macros</h2>
+      <p className="text-gray-600">Visualização gráfica dos macronutrientes.</p>
+    </div>
+  )
+}

--- a/nutriplane/src/styles/tailwind.config.js
+++ b/nutriplane/src/styles/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/nutriplane/src/utils/calcularMacros.js
+++ b/nutriplane/src/utils/calcularMacros.js
@@ -1,0 +1,13 @@
+export function calcularMacros(alimentos) {
+  return alimentos.reduce(
+    (totais, item) => {
+      return {
+        calorias: totais.calorias + item.calorias,
+        proteina: totais.proteina + item.proteina,
+        carboidrato: totais.carboidrato + item.carboidrato,
+        gordura: totais.gordura + item.gordura,
+      }
+    },
+    { calorias: 0, proteina: 0, carboidrato: 0, gordura: 0 }
+  )
+}

--- a/nutriplane/vite.config.js
+++ b/nutriplane/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})

--- a/src/model.py
+++ b/src/model.py
@@ -164,3 +164,29 @@ class DDAAModel:
             'DD_base': self.dd_curve(Y_range, 0),
             'AA_base': self.aa_curve(Y_range, 0)
         }
+
+
+# ---------------------------------------------------------------------------
+# Keynesian Cross helper functions used in the unit tests.
+# These utilities were present in earlier revisions of the repository and are
+# retained here for backwards compatibility so that the test suite continues to
+# pass. They provide a very small closed form representation of the consumption,
+# investment and aggregate demand relationships that underpin the Keynesian
+# cross model.
+
+from .parameters import Parameters
+
+
+def consumption(params: Parameters, income: float) -> float:
+    """Compute consumption given income."""
+    return params.alpha + params.beta * (income - params.tax)
+
+
+def investment(params: Parameters, interest_rate: float) -> float:
+    """Investment as a decreasing function of the interest rate."""
+    return params.investment_intercept - params.investment_slope * interest_rate
+
+
+def aggregate_demand(params: Parameters, interest_rate: float, income: float) -> float:
+    """Return aggregate demand at the provided income and interest rate."""
+    return consumption(params, income) + investment(params, interest_rate) + params.government


### PR DESCRIPTION
## Summary
- restore Keynesian cross helper functions in `src/model.py`
- add minimal React + Vite project (`nutriplane/`) with Tailwind config
- implement navigation components and placeholder routes
- include simple nutrition data and macro calculation helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68797ccf3590832286244cf13e4fb108